### PR TITLE
remove unnecessary AWS config

### DIFF
--- a/terraform/aws.tf
+++ b/terraform/aws.tf
@@ -1,9 +1,0 @@
-provider "aws" {
-  version = "~> 0.1"
-  region = "${var.aws_region}"
-}
-
-terraform {
-  backend "s3" {
-  }
-}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,3 @@
-output "aws_region" {
-  value = "${var.aws_region}"
-}
-
 output "aws_az1" {
   value = "${var.aws_az1}"
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,8 +1,5 @@
 # On strings, note the following: only lowercase alphanumeric characters, hyphens, underscores, periods, and spaces allowed.
 
-# Type: String, must be a valid AWS region
-aws_region = "<aws region>"
-
 # Type: String, must be a valid AWS AZ
 aws_az1 = "<aws az1>"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,3 @@
-variable "aws_region" {
-  type = "string"
-}
 variable "aws_az1" {
   type = "string"
 }

--- a/terraform/vpc-mgmt.tf
+++ b/terraform/vpc-mgmt.tf
@@ -1,7 +1,3 @@
-data "aws_region" "current" {
-  current = true
-}
-
 module "mgmt-vpc" {
   source = "github.com/terraform-community-modules/tf_aws_vpc"
 


### PR DESCRIPTION
Broken out from #10.

Since this repository is meant to be used as a module rather than set up with Terraform directly, taking out the `provider` and the AWS region configuration that goes with it.