### PR TITLE
fix path to flow log files

### DIFF
--- a/terraform/flow_logs.tf
+++ b/terraform/flow_logs.tf
@@ -4,13 +4,13 @@ resource "aws_cloudwatch_log_group" "devsecops_log_group" {
 
 resource "aws_iam_role" "devsecops_iam_log_role" {
   name = "${var.devsecops_iam_log_role_name}"
-  assume_role_policy = "${file("files/assume_vpc_flow_logs_role_policy.json")}"
+  assume_role_policy = "${file("${path.module}/files/assume_vpc_flow_logs_role_policy.json")}"
 }
 
 resource "aws_iam_role_policy" "devsecops_log_policy" {
   name = "${var.devsecops_flow_log_policy}"
   role = "${aws_iam_role.devsecops_iam_log_role.id}"
-  policy = "${file("files/devsecops_iam_flow_log_policy.json")}"
+  policy = "${file("${path.module}/files/devsecops_iam_flow_log_policy.json")}"
 }
 
 resource "aws_flow_log" "test_flow_log" {


### PR DESCRIPTION
Broken out from #10.

Referencing path within the module, rather than within the working directory. This fixes the code when used as a module, rather than directly.