### PR TITLE
 remove Important Concepts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ You may wish to consult the following example repos for ideas or templates to de
 
 * [`terraform/`](terraform/) - [Terraform](https://www.terraform.io/) code for setting up the infrastructure at the [Amazon Web Services (AWS)](https://aws.amazon.com/) level
 
-## Important concepts
-
-### Configuration as code
-
-All configuration is code, and [all setup steps are documented](#setup). New environment(s) can be created from scratch quickly and reliably.
-
-### DRY
-
-The code follows the [Don't Repeat Yourself (DRY)](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle. Values that need to be shared are passed around as variables, rather than being hard-coded in multiple places. This ensures configuration stays in sync.
-
 ## Using the Modules
 
 Using the modules is as easy as declaring them in your code, along with a pointer to the proper location. For example, the following terraform code will declare a VPC flow log using the module presented here.


### PR DESCRIPTION
Moved this to [the Design Considerations doc](https://docs.google.com/document/d/1xpQUSBDP8not-AbChf_vM2grdGzDE83IJYx9i9W00Qc/edit#heading=h.b6ztauie5ret), which is a more centralized place we were already putting this type of information.

/cc https://github.com/GSA/devsecops-example/pull/31